### PR TITLE
Bump Delve and Go versions

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.suse.com/suse/sle15:15.7
 
-ARG GO_VERSION=1.24
-ARG DLV_VERSION=1.25.1
+ARG GO_VERSION=1.25
+ARG DLV_VERSION=1.25.2
 ARG DELVE_DEBUGGER_VERSION=0
 
 RUN zypper --non-interactive install --no-recommends go${GO_VERSION} git sudo procps


### PR DESCRIPTION
Current image can't debug binaries built with Go v1.25+ - this PR bumps versions of Delve and Go to the latest available.